### PR TITLE
Support gradle 6.6 or newer version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,26 +2,26 @@ plugins {
     id "java-gradle-plugin"
 }
 
-apply plugin: "maven"
+apply plugin: "maven-publish"
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 group = "com.github.yuki-0710"
-version = "2.0.0"
+version = "2.0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile "com.amazonaws:aws-java-sdk-sts:1.11.613"
+    implementation "com.amazonaws:aws-java-sdk-sts:1.11.613"
 }
 
-uploadArchives {
+publishing {
     repositories {
-        mavenDeployer {
-            repository(url: uri(getProperty("github.repository.path")))
+        maven {
+            url = uri(getProperty("github.repository.path"))
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request introduces a shim for a breaking change of `AbstractAuthenticationSupportedRepository#getConfiguredCredentials()`.

Since gradle 6.6, `AbstractAuthenticationSupportedRepository#getConfiguredCredentials()` retunrs `Property<Credentials>` as the result instad of `Credentials` object.

This breaking change makes like the following error on the newer (i.e. >= 6.6) gradle:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':my-project'.
> Failed to notify project evaluation listener.
   > 'org.gradle.api.credentials.Credentials org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository.getConfiguredCredentials()'
```

This commit introduces a shim layer to support both versions' behaviors.

---

And I modified `build.gradle` to follow Gradle 7.1 notation, but possibly it cannot publish an artifact property. If so, could you please adjust it?